### PR TITLE
[Editorial] Possible typo fix: Wrecker -> wrecked

### DIFF
--- a/src/epub/text/chapter-18.xhtml
+++ b/src/epub/text/chapter-18.xhtml
@@ -27,7 +27,7 @@
 			<p>“If you have a good memory of it, yes. But how know you these ships?”</p>
 			<p>“I was in one once for many days. If these are alike, then I know it well!”</p>
 			<p>“And if this is unlike, to try such may mean your death.”</p>
-			<p>He had to accept her warning. Yet outwardly this ship was a duplicate. And before he had voyaged on the derelict he had also explored a Wrecker freighter on his own world thousands of years before his own race had evolved. There was one portion of both ships which had been identical⁠—save for size⁠—and that part was the best for his purpose.</p>
+			<p>He had to accept her warning. Yet outwardly this ship was a duplicate. And before he had voyaged on the derelict he had also explored a wrecked freighter on his own world thousands of years before his own race had evolved. There was one portion of both ships which had been identical⁠—save for size⁠—and that part was the best for his purpose.</p>
 			<p>“Send me⁠—here!”</p>
 			<p>With closed eyes, Ross produced a mental picture of the control cabin. Those seats which were not really seats but webbing support swinging before banks of buttons and levers; all the other installations he had watched, studied, until they were as known to him as the plate bulkheads of the cabin below in which he had slept. Very vivid, that memory. He felt the touch of the Foanna’s cool fingers on his forehead⁠—then it was gone. He opened his eyes.</p>
 			<p>No more wind and gloom, he stood directly behind the pilot’s web-sling, facing a vista-plate and rows of controls, just as he had stood so many times in the derelict. He had made it! This was the control cabin of the spacer. And it was alive⁠—the faint thrumming in the air, the play of lights on the boards.</p>


### PR DESCRIPTION
Text in scans at archive.org refers to a "Wrecker freighter" that the character explored before, but context indicates it's a damaged spaceship from the first book in the series, while the Wreckers are the land-based faction of the non-space-faring natives in this book. Seems likely it was a typo in the original.